### PR TITLE
Add wrapper request metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+- Added Authsignal SDK identity/version headers and wrapper-aware User-Agent metadata for native mobile requests.
+
 ## 2.4.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^2.4.0
+  authsignal_flutter: ^2.4.1
 ```
 
 Then install the package:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.authsignal.authsignal_flutter'
-version '2.4.0'
+version '2.4.1'
 
 buildscript {
     ext.kotlin_version = '1.7.10'
@@ -46,9 +46,14 @@ android {
 
     defaultConfig {
         minSdkVersion 23
+        buildConfigField "String", "VERSION_NAME", "\"${project.version}\""
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     dependencies {
-        implementation 'com.authsignal:authsignal-android:3.8.0'
+        implementation 'com.authsignal:authsignal-android:3.9.1'
     }
 }

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -2,6 +2,7 @@ package com.authsignal.authsignal_flutter
 
 import android.app.Activity
 import android.content.Context
+import com.authsignal.AuthsignalRequestMetadata
 import com.authsignal.DeviceCache
 import com.authsignal.TokenCache
 import com.authsignal.email.AuthsignalEmail
@@ -54,6 +55,12 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         val tenantID = call.argument<String>("tenantID")!!
         val baseURL = call.argument<String>("baseURL")!!
         val deviceID = call.argument<String>("deviceID")
+
+        AuthsignalRequestMetadata.setWrapperSDK(
+          sdk = "flutter",
+          version = BuildConfig.VERSION_NAME,
+          userAgentToken = "AuthsignalFlutterSDK",
+        )
 
         context?.let {
           DeviceCache.shared.initialize(it, deviceID)

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -2,6 +2,8 @@ import Flutter
 import UIKit
 import Authsignal
 
+private let authsignalFlutterVersion = "2.4.1"
+
 public class AuthsignalPlugin: NSObject, FlutterPlugin {
   var passkey: AuthsignalPasskey?
   var push: AuthsignalPush?
@@ -28,6 +30,12 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
       let tenantID = arguments["tenantID"] as! String
       let baseURL = arguments["baseURL"] as! String
       let deviceID = arguments["deviceID"] as? String
+
+      AuthsignalRequestMetadata.setWrapperSDK(
+        "flutter",
+        version: authsignalFlutterVersion,
+        userAgentToken: "AuthsignalFlutterSDK"
+      )
 
       self.customDeviceID = deviceID
       self.passkey = AuthsignalPasskey(tenantID: tenantID, baseURL: baseURL, deviceID: deviceID)

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '2.4.0'
+  s.version          = '2.4.1'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Authsignal', '~> 2.7'
+  s.dependency 'Authsignal', '~> 2.8.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 2.4.0
+version: 2.4.1
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:


### PR DESCRIPTION
### New Features
- Sets Flutter wrapper metadata during native initialization so Flutter traffic is identified as Flutter instead of plain Android/iOS.

### Checklist
- [x] Version bumped

