### PR TITLE
[codex] Add passkey sync support to Flutter SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.7.0
 
-- Added passkey credential sync support with `syncCredentials` enabled by default for sign-up and sign-in.
+- Added opt-in passkey credential sync support with `syncCredentials` for sign-up and sign-in.
 - Updated native dependencies to Authsignal iOS `~> 2.10.0` and Authsignal Android `3.11.0`.
 - Raised Android build tooling to support AndroidX Credentials 1.6.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.0
+
+- Added passkey credential sync support with `syncCredentials` enabled by default for sign-up and sign-in.
+- Updated native dependencies to Authsignal iOS `~> 2.10.0` and Authsignal Android `3.11.0`.
+- Raised Android build tooling to support AndroidX Credentials 1.6.0.
+
 ## 2.6.0
 
 - Added an optional `pushToken` parameter to `push.addCredential` for registering a device push token during enrollment.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^2.5.0
+  authsignal_flutter: ^2.7.0
 ```
 
 Then install the package:
@@ -24,6 +24,8 @@ For iOS apps, install CocoaPods dependencies:
 ```bash
 cd ios && pod install
 ```
+
+For Android apps, use compile SDK 35 and Android Gradle Plugin 8.6.0 or newer.
 
 ## Initialization
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,15 @@
 group 'com.authsignal.authsignal_flutter'
-version '2.5.0'
+version '2.7.0'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.1.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -29,7 +29,7 @@ android {
         namespace 'com.authsignal.authsignal_flutter'
     }
 
-    compileSdkVersion 33
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.authsignal:authsignal-android:3.10.0'
+        implementation 'com.authsignal:authsignal-android:3.11.0'
         implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
     }
 }

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -102,6 +102,7 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         val displayName = call.argument<String>("displayName")
         val ignorePasskeyAlreadyExistsError =
           call.argument<Boolean>("ignorePasskeyAlreadyExistsError") ?: false
+        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: true
 
         coroutineScope.launch {
           val response = passkey.signUp(
@@ -109,6 +110,7 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
             username = username,
             displayName = displayName,
             ignorePasskeyAlreadyExistsError = ignorePasskeyAlreadyExistsError,
+            syncCredentials = syncCredentials,
           )
 
           handleResponse(response, result)?.let {
@@ -126,12 +128,14 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         val token = call.argument<String>("token")
         val preferImmediatelyAvailableCredentials =
           call.argument<Boolean>("preferImmediatelyAvailableCredentials") ?: true
+        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: true
 
         coroutineScope.launch {
           val response = passkey.signIn(
             action = action,
             token = token,
             preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials,
+            syncCredentials = syncCredentials,
           )
 
           handleResponse(response, result)?.let {

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -102,7 +102,7 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         val displayName = call.argument<String>("displayName")
         val ignorePasskeyAlreadyExistsError =
           call.argument<Boolean>("ignorePasskeyAlreadyExistsError") ?: false
-        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: true
+        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: false
 
         coroutineScope.launch {
           val response = passkey.signUp(
@@ -128,7 +128,7 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         val token = call.argument<String>("token")
         val preferImmediatelyAvailableCredentials =
           call.argument<Boolean>("preferImmediatelyAvailableCredentials") ?: true
-        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: true
+        val syncCredentials = call.argument<Boolean>("syncCredentials") ?: false
 
         coroutineScope.launch {
           val response = passkey.signIn(

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import Authsignal
 
-private let authsignalFlutterVersion = "2.4.1"
+private let authsignalFlutterVersion = "2.7.0"
 
 public class AuthsignalPlugin: NSObject, FlutterPlugin {
   var passkey: AuthsignalPasskey?
@@ -65,13 +65,15 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
       let username = arguments["username"] as? String
       let displayName = arguments["displayName"] as? String
       let ignorePasskeyAlreadyExistsError = arguments["ignorePasskeyAlreadyExistsError"] as? Bool ?? false
+      let syncCredentials = arguments["syncCredentials"] as? Bool ?? true
 
       Task.init {
         let response = await self.passkey!.signUp(
           token: token,
           username: username,
           displayName: displayName,
-          ignorePasskeyAlreadyExistsError: ignorePasskeyAlreadyExistsError
+          ignorePasskeyAlreadyExistsError: ignorePasskeyAlreadyExistsError,
+          syncCredentials: syncCredentials
         )
 
         if response.error != nil {
@@ -92,13 +94,15 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
       let token = arguments["token"] as? String
       let autofill = arguments["autofill"] as? Bool ?? false
       let preferImmediatelyAvailableCredentials = arguments["preferImmediatelyAvailableCredentials"] as? Bool ?? true
+      let syncCredentials = arguments["syncCredentials"] as? Bool ?? true
 
       Task.init {
         let response = await self.passkey!.signIn(
           token: token,
           action: action,
           autofill: autofill,
-          preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
+          preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials,
+          syncCredentials: syncCredentials
         )
 
         if response.error != nil {

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -65,7 +65,7 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
       let username = arguments["username"] as? String
       let displayName = arguments["displayName"] as? String
       let ignorePasskeyAlreadyExistsError = arguments["ignorePasskeyAlreadyExistsError"] as? Bool ?? false
-      let syncCredentials = arguments["syncCredentials"] as? Bool ?? true
+      let syncCredentials = arguments["syncCredentials"] as? Bool ?? false
 
       Task.init {
         let response = await self.passkey!.signUp(
@@ -94,7 +94,7 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
       let token = arguments["token"] as? String
       let autofill = arguments["autofill"] as? Bool ?? false
       let preferImmediatelyAvailableCredentials = arguments["preferImmediatelyAvailableCredentials"] as? Bool ?? true
-      let syncCredentials = arguments["syncCredentials"] as? Bool ?? true
+      let syncCredentials = arguments["syncCredentials"] as? Bool ?? false
 
       Task.init {
         let response = await self.passkey!.signIn(

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '2.5.0'
+  s.version          = '2.7.0'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Authsignal', '~> 2.9.0'
+  s.dependency 'Authsignal', '~> 2.10.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/authsignal_flutter_platform.dart
+++ b/lib/src/authsignal_flutter_platform.dart
@@ -54,6 +54,7 @@ abstract class AuthsignalFlutterPlatform extends PlatformInterface {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
+    bool syncCredentials = true,
   }) {
     throw UnimplementedError('passkeySignUp() has not been implemented.');
   }
@@ -63,6 +64,7 @@ abstract class AuthsignalFlutterPlatform extends PlatformInterface {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
+    bool syncCredentials = true,
   }) {
     throw UnimplementedError('passkeySignIn() has not been implemented.');
   }

--- a/lib/src/authsignal_flutter_platform.dart
+++ b/lib/src/authsignal_flutter_platform.dart
@@ -54,7 +54,7 @@ abstract class AuthsignalFlutterPlatform extends PlatformInterface {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) {
     throw UnimplementedError('passkeySignUp() has not been implemented.');
   }
@@ -64,7 +64,7 @@ abstract class AuthsignalFlutterPlatform extends PlatformInterface {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) {
     throw UnimplementedError('passkeySignIn() has not been implemented.');
   }

--- a/lib/src/authsignal_flutter_web.dart
+++ b/lib/src/authsignal_flutter_web.dart
@@ -165,7 +165,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) {
     final client = _client;
     if (client == null) {
@@ -221,7 +221,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) {
     final client = _client;
     if (client == null) {

--- a/lib/src/authsignal_flutter_web.dart
+++ b/lib/src/authsignal_flutter_web.dart
@@ -165,6 +165,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
+    bool syncCredentials = true,
   }) {
     final client = _client;
     if (client == null) {
@@ -184,6 +185,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
       'token': effectiveToken,
       if (username != null) 'username': username,
       if (displayName != null) 'displayName': displayName,
+      'syncCredentials': syncCredentials,
     };
     if (useAutoRegister) {
       payload['useAutoRegister'] = true;
@@ -219,6 +221,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
+    bool syncCredentials = true,
   }) {
     final client = _client;
     if (client == null) {
@@ -231,6 +234,7 @@ class AuthsignalFlutterWeb extends AuthsignalFlutterPlatform {
       if (autofill) 'autofill': true,
       'preferImmediatelyAvailableCredentials':
           preferImmediatelyAvailableCredentials,
+      'syncCredentials': syncCredentials,
     };
 
     return _invokePasskeyMethod(

--- a/lib/src/authsignal_passkey.dart
+++ b/lib/src/authsignal_passkey.dart
@@ -16,6 +16,7 @@ class AuthsignalPasskey {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
+    bool syncCredentials = true,
   }) async {
     await initCheck();
 
@@ -25,6 +26,7 @@ class AuthsignalPasskey {
       displayName: displayName,
       useAutoRegister: useAutoRegister,
       ignorePasskeyAlreadyExistsError: ignorePasskeyAlreadyExistsError,
+      syncCredentials: syncCredentials,
     );
   }
 
@@ -33,6 +35,7 @@ class AuthsignalPasskey {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
+    bool syncCredentials = true,
   }) async {
     await initCheck();
 
@@ -51,6 +54,7 @@ class AuthsignalPasskey {
         autofill: autofill,
         preferImmediatelyAvailableCredentials:
             preferImmediatelyAvailableCredentials,
+        syncCredentials: syncCredentials,
       );
       return response;
     } finally {

--- a/lib/src/authsignal_passkey.dart
+++ b/lib/src/authsignal_passkey.dart
@@ -16,7 +16,7 @@ class AuthsignalPasskey {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) async {
     await initCheck();
 
@@ -35,7 +35,7 @@ class AuthsignalPasskey {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) async {
     await initCheck();
 

--- a/lib/src/method_channel_authsignal_flutter.dart
+++ b/lib/src/method_channel_authsignal_flutter.dart
@@ -93,12 +93,14 @@ class MethodChannelAuthsignalFlutter extends AuthsignalFlutterPlatform {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
+    bool syncCredentials = true,
   }) async {
     final arguments = <String, dynamic>{
       'token': token,
       'username': username,
       'displayName': displayName,
       'ignorePasskeyAlreadyExistsError': ignorePasskeyAlreadyExistsError,
+      'syncCredentials': syncCredentials,
     };
     if (useAutoRegister) {
       arguments['useAutoRegister'] = useAutoRegister;
@@ -126,6 +128,7 @@ class MethodChannelAuthsignalFlutter extends AuthsignalFlutterPlatform {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
+    bool syncCredentials = true,
   }) async {
     final arguments = <String, dynamic>{
       'action': action,
@@ -133,6 +136,7 @@ class MethodChannelAuthsignalFlutter extends AuthsignalFlutterPlatform {
       'autofill': autofill,
       'preferImmediatelyAvailableCredentials':
           preferImmediatelyAvailableCredentials,
+      'syncCredentials': syncCredentials,
     };
 
     try {

--- a/lib/src/method_channel_authsignal_flutter.dart
+++ b/lib/src/method_channel_authsignal_flutter.dart
@@ -93,7 +93,7 @@ class MethodChannelAuthsignalFlutter extends AuthsignalFlutterPlatform {
     String? displayName,
     bool useAutoRegister = false,
     bool ignorePasskeyAlreadyExistsError = false,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) async {
     final arguments = <String, dynamic>{
       'token': token,
@@ -128,7 +128,7 @@ class MethodChannelAuthsignalFlutter extends AuthsignalFlutterPlatform {
     String? token,
     bool autofill = false,
     bool preferImmediatelyAvailableCredentials = true,
-    bool syncCredentials = true,
+    bool syncCredentials = false,
   }) async {
     final arguments = <String, dynamic>{
       'action': action,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 2.6.0
+version: 2.7.0
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:

--- a/test/authsignal_test.dart
+++ b/test/authsignal_test.dart
@@ -8,16 +8,12 @@ void main() {
   const MethodChannel channel = MethodChannel('authsignal');
 
   Authsignal authsignal = Authsignal(tenantID: 'mock_tenant_id');
-  late List<MethodCall> methodCalls;
 
   setUp(() {
-    methodCalls = [];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
-        methodCalls.add(methodCall);
-
         switch (methodCall.method) {
           case "initialize":
             {
@@ -27,18 +23,6 @@ void main() {
           case "passkey.signUp":
             {
               return <String, dynamic>{'token': 'result_token'};
-            }
-
-          case "passkey.signIn":
-            {
-              return <String, dynamic>{
-                'isVerified': true,
-                'token': 'sign_in_token',
-                'userId': 'test_user_id',
-                'userAuthenticatorId': 'test_authenticator_id',
-                'username': 'test_username',
-                'displayName': 'Test User',
-              };
             }
 
           case "push.getCredential":
@@ -220,56 +204,6 @@ void main() {
         .signUp(token: 'initial_token', username: 'bob');
 
     expect(result.data!.token, 'result_token');
-  });
-
-  test('passkey.signUp defaults syncCredentials to false', () async {
-    await authsignal.passkey.signUp(
-      token: 'initial_token',
-      username: 'bob',
-    );
-
-    final call =
-        methodCalls.lastWhere((call) => call.method == 'passkey.signUp');
-    final arguments = call.arguments as Map<Object?, Object?>;
-
-    expect(arguments['syncCredentials'], false);
-  });
-
-  test('passkey.signUp forwards syncCredentials', () async {
-    await authsignal.passkey.signUp(
-      token: 'initial_token',
-      username: 'bob',
-      syncCredentials: true,
-    );
-
-    final call =
-        methodCalls.lastWhere((call) => call.method == 'passkey.signUp');
-    final arguments = call.arguments as Map<Object?, Object?>;
-
-    expect(arguments['syncCredentials'], true);
-  });
-
-  test('passkey.signIn defaults syncCredentials to false', () async {
-    await authsignal.passkey.signIn(token: 'initial_token');
-
-    final call =
-        methodCalls.lastWhere((call) => call.method == 'passkey.signIn');
-    final arguments = call.arguments as Map<Object?, Object?>;
-
-    expect(arguments['syncCredentials'], false);
-  });
-
-  test('passkey.signIn forwards syncCredentials', () async {
-    await authsignal.passkey.signIn(
-      token: 'initial_token',
-      syncCredentials: true,
-    );
-
-    final call =
-        methodCalls.lastWhere((call) => call.method == 'passkey.signIn');
-    final arguments = call.arguments as Map<Object?, Object?>;
-
-    expect(arguments['syncCredentials'], true);
   });
 
   test('push.getCredential', () async {

--- a/test/authsignal_test.dart
+++ b/test/authsignal_test.dart
@@ -222,11 +222,10 @@ void main() {
     expect(result.data!.token, 'result_token');
   });
 
-  test('passkey.signUp forwards syncCredentials', () async {
+  test('passkey.signUp defaults syncCredentials to false', () async {
     await authsignal.passkey.signUp(
       token: 'initial_token',
       username: 'bob',
-      syncCredentials: false,
     );
 
     final call =
@@ -236,17 +235,41 @@ void main() {
     expect(arguments['syncCredentials'], false);
   });
 
-  test('passkey.signIn forwards syncCredentials', () async {
-    await authsignal.passkey.signIn(
+  test('passkey.signUp forwards syncCredentials', () async {
+    await authsignal.passkey.signUp(
       token: 'initial_token',
-      syncCredentials: false,
+      username: 'bob',
+      syncCredentials: true,
     );
+
+    final call =
+        methodCalls.lastWhere((call) => call.method == 'passkey.signUp');
+    final arguments = call.arguments as Map<Object?, Object?>;
+
+    expect(arguments['syncCredentials'], true);
+  });
+
+  test('passkey.signIn defaults syncCredentials to false', () async {
+    await authsignal.passkey.signIn(token: 'initial_token');
 
     final call =
         methodCalls.lastWhere((call) => call.method == 'passkey.signIn');
     final arguments = call.arguments as Map<Object?, Object?>;
 
     expect(arguments['syncCredentials'], false);
+  });
+
+  test('passkey.signIn forwards syncCredentials', () async {
+    await authsignal.passkey.signIn(
+      token: 'initial_token',
+      syncCredentials: true,
+    );
+
+    final call =
+        methodCalls.lastWhere((call) => call.method == 'passkey.signIn');
+    final arguments = call.arguments as Map<Object?, Object?>;
+
+    expect(arguments['syncCredentials'], true);
   });
 
   test('push.getCredential', () async {

--- a/test/authsignal_test.dart
+++ b/test/authsignal_test.dart
@@ -8,12 +8,16 @@ void main() {
   const MethodChannel channel = MethodChannel('authsignal');
 
   Authsignal authsignal = Authsignal(tenantID: 'mock_tenant_id');
+  late List<MethodCall> methodCalls;
 
   setUp(() {
+    methodCalls = [];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
+        methodCalls.add(methodCall);
+
         switch (methodCall.method) {
           case "initialize":
             {
@@ -23,6 +27,18 @@ void main() {
           case "passkey.signUp":
             {
               return <String, dynamic>{'token': 'result_token'};
+            }
+
+          case "passkey.signIn":
+            {
+              return <String, dynamic>{
+                'isVerified': true,
+                'token': 'sign_in_token',
+                'userId': 'test_user_id',
+                'userAuthenticatorId': 'test_authenticator_id',
+                'username': 'test_username',
+                'displayName': 'Test User',
+              };
             }
 
           case "push.getCredential":
@@ -204,6 +220,33 @@ void main() {
         .signUp(token: 'initial_token', username: 'bob');
 
     expect(result.data!.token, 'result_token');
+  });
+
+  test('passkey.signUp forwards syncCredentials', () async {
+    await authsignal.passkey.signUp(
+      token: 'initial_token',
+      username: 'bob',
+      syncCredentials: false,
+    );
+
+    final call =
+        methodCalls.lastWhere((call) => call.method == 'passkey.signUp');
+    final arguments = call.arguments as Map<Object?, Object?>;
+
+    expect(arguments['syncCredentials'], false);
+  });
+
+  test('passkey.signIn forwards syncCredentials', () async {
+    await authsignal.passkey.signIn(
+      token: 'initial_token',
+      syncCredentials: false,
+    );
+
+    final call =
+        methodCalls.lastWhere((call) => call.method == 'passkey.signIn');
+    final arguments = call.arguments as Map<Object?, Object?>;
+
+    expect(arguments['syncCredentials'], false);
   });
 
   test('push.getCredential', () async {


### PR DESCRIPTION
### Breaking Changes

### New Features
1. Added opt-in passkey credential sync with `syncCredentials` defaulting to `false`.

### Bug Fixes

### Checklist
- [x] Version bumped
- [x] Documentation updated