### PR TITLE
Add push credential update support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0
+
+- Added `push.updateCredential(pushToken)` so enrolled devices can refresh their push token.
+- Updated native dependencies to Authsignal iOS `~> 2.11.0` and Authsignal Android `4.1.0`.
+
 ## 3.0.0
 
 - Updated the Android dependency to Authsignal Android `4.0.0`, which is compiled against Ktor 3.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^3.0.0
+  authsignal_flutter: ^3.1.0
 ```
 
 Then install the package:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.authsignal.authsignal_flutter'
-version '3.0.0'
+version '3.1.0'
 
 buildscript {
     ext.kotlin_version = '2.1.21'
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.authsignal:authsignal-android:4.0.0'
+        implementation 'com.authsignal:authsignal-android:4.1.0'
         implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
     }
 }

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -268,6 +268,25 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
         }
       }
 
+      "push.updateCredential" -> {
+        val pushToken = call.argument<String>("pushToken")!!
+
+        coroutineScope.launch {
+          val response = push.updateCredential(pushToken)
+
+          handleResponse(response, result)?.let {
+            val data = mapOf(
+              "userAuthenticatorId" to it.userAuthenticatorId,
+              "userId" to it.userId,
+              "lastVerifiedAt" to it.lastVerifiedAt,
+              "pushToken" to it.pushToken,
+            )
+
+            result.success(data)
+          }
+        }
+      }
+
       "email.enroll" -> {
         val emailAddress = call.argument<String>("email")!!
 

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -939,6 +939,11 @@ class _HomeScreenState extends State<HomeScreen> {
           label: const Text('Enroll Push'),
         ),
         ElevatedButton.icon(
+          onPressed: _isInitialized ? _updatePushCredential : null,
+          icon: const Icon(Icons.sync, size: 18),
+          label: const Text('Update Token'),
+        ),
+        ElevatedButton.icon(
           onPressed: _isInitialized ? _getPushChallenge : null,
           icon: const Icon(Icons.notifications_active, size: 18),
           label: const Text('Get Challenge'),
@@ -1021,6 +1026,33 @@ class _HomeScreenState extends State<HomeScreen> {
         _addOutput('   User ID: ${result.data!.userId}');
       } else {
         _addOutput('❌ Failed to enroll push: ${result.error}');
+      }
+    } catch (e) {
+      _addOutput('❌ Error: $e');
+    }
+  }
+
+  Future<void> _updatePushCredential() async {
+    try {
+      final pushToken = await PushService.getPushToken();
+      if (pushToken == null) {
+        _addOutput('❌ No push token available to update the credential');
+        _addOutput('   Check simulator/device push configuration');
+        return;
+      }
+
+      _addOutput('📬 Updating push credential token...');
+      _addOutput('   Push token (${PushService.mode.name}): '
+          '${pushToken.substring(0, pushToken.length.clamp(0, 12))}…');
+
+      final result = await authsignal.push.updateCredential(pushToken);
+
+      if (result.data != null) {
+        _addOutput('✅ Push credential updated!');
+        _addOutput('   Authenticator ID: ${result.data!.userAuthenticatorId}');
+        _addOutput('   User ID: ${result.data!.userId}');
+      } else {
+        _addOutput('❌ Failed to update push credential: ${result.error}');
       }
     } catch (e) {
       _addOutput('❌ Error: $e');

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import Authsignal
 
-private let authsignalFlutterVersion = "3.0.0"
+private let authsignalFlutterVersion = "3.1.0"
 
 public class AuthsignalPlugin: NSObject, FlutterPlugin {
   var passkey: AuthsignalPasskey?
@@ -267,6 +267,30 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
           result(error)
         } else {
           result(response.data)
+        }
+      }
+
+    case "push.updateCredential":
+      let arguments = call.arguments as! [String: Any]
+      let pushToken = arguments["pushToken"] as! String
+
+      Task.init {
+        let response = await self.push!.updateCredential(pushToken: pushToken)
+
+        if response.error != nil {
+          let error = FlutterError(code: response.errorCode ?? "unexpected_error", message: response.error, details: "")
+          result(error)
+        } else if let data = response.data {
+          let credential: [String: String?] = [
+            "userAuthenticatorId": data.userAuthenticatorId,
+            "userId": data.userId,
+            "lastVerifiedAt": data.lastVerifiedAt,
+            "pushToken": data.pushToken,
+          ]
+
+          result(credential)
+        } else {
+          result(nil)
         }
       }
 

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Authsignal', '~> 2.10.0'
+  s.dependency 'Authsignal', '~> 2.11.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/authsignal_flutter.dart
+++ b/lib/authsignal_flutter.dart
@@ -18,6 +18,7 @@ export 'src/types.dart'
         TokenPayloadOther,
         ErrorCode,
         AppCredential,
+        UpdatedAppCredential,
         AppChallenge,
         SignUpResponse,
         SignInResponse,

--- a/lib/src/authsignal_push.dart
+++ b/lib/src/authsignal_push.dart
@@ -119,4 +119,24 @@ class AuthsignalPush {
       return AuthsignalResponse.fromError(ex);
     }
   }
+
+  Future<AuthsignalResponse<UpdatedAppCredential>> updateCredential(
+      String pushToken) async {
+    await initCheck();
+
+    final arguments = <String, dynamic>{'pushToken': pushToken};
+
+    try {
+      final data = await methodChannel.invokeMapMethod<String, dynamic>(
+          'push.updateCredential', arguments);
+
+      if (data != null) {
+        return AuthsignalResponse(data: UpdatedAppCredential.fromMap(data));
+      } else {
+        return AuthsignalResponse(data: null);
+      }
+    } on PlatformException catch (ex) {
+      return AuthsignalResponse.fromError(ex);
+    }
+  }
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -110,6 +110,29 @@ class AppCredential {
   }
 }
 
+class UpdatedAppCredential {
+  final String userAuthenticatorId;
+  final String userId;
+  final String lastVerifiedAt;
+  final String pushToken;
+
+  UpdatedAppCredential({
+    required this.userAuthenticatorId,
+    required this.userId,
+    required this.lastVerifiedAt,
+    required this.pushToken,
+  });
+
+  factory UpdatedAppCredential.fromMap(Map<String, dynamic> map) {
+    return UpdatedAppCredential(
+      userAuthenticatorId: map['userAuthenticatorId'],
+      userId: map['userId'],
+      lastVerifiedAt: map['lastVerifiedAt'],
+      pushToken: map['pushToken'],
+    );
+  }
+}
+
 class AppChallenge {
   final String challengeId;
   final String? actionCode;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 3.0.0
+version: 3.1.0
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:

--- a/test/authsignal_test.dart
+++ b/test/authsignal_test.dart
@@ -67,6 +67,16 @@ void main() {
               return true;
             }
 
+          case "push.updateCredential":
+            {
+              return <String, dynamic>{
+                'userAuthenticatorId': 'test_push_authenticator_id',
+                'userId': 'test_user_id',
+                'lastVerifiedAt': '2023-01-03T00:00:00Z',
+                'pushToken': methodCall.arguments['pushToken'],
+              };
+            }
+
           case "qr.getCredential":
             {
               return <String, dynamic>{
@@ -248,6 +258,15 @@ void main() {
     );
 
     expect(result.data, true);
+  });
+
+  test('push.updateCredential', () async {
+    final result = await authsignal.push.updateCredential('test-push-token');
+
+    expect(result.data!.userAuthenticatorId, 'test_push_authenticator_id');
+    expect(result.data!.userId, 'test_user_id');
+    expect(result.data!.lastVerifiedAt, '2023-01-03T00:00:00Z');
+    expect(result.data!.pushToken, 'test-push-token');
   });
 
   test('qr.getCredential', () async {


### PR DESCRIPTION
### Breaking Changes
None.

### New Features
- Added `push.updateCredential(pushToken)` for refreshing push tokens.
- Updated native SDK deps to iOS `~> 2.11.0` and Android `4.1.0`.

### Bug Fixes
None.

### Checklist
- [x] Version bumped
- [ ] Documentation updated
