### PR TITLE
Add push credential expiry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0
+
+- Added push credential expiry support with `push.updateCredential(UpdateCredentialInput(resetExpiry: true))`.
+- Added optional `expiresAt` fields to push credential responses.
+- Updated native dependencies to Authsignal iOS `~> 2.12.0` and Authsignal Android `4.2.0`.
+
 ## 3.1.0
 
 - Added `push.updateCredential(pushToken)` so enrolled devices can refresh their push token.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^3.1.0
+  authsignal_flutter: ^3.2.0
 ```
 
 Then install the package:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.authsignal.authsignal_flutter'
-version '3.1.0'
+version '3.2.0'
 
 buildscript {
     ext.kotlin_version = '2.1.21'
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.authsignal:authsignal-android:4.1.0'
+        implementation 'com.authsignal:authsignal-android:4.2.0'
         implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
     }
 }

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -190,7 +190,8 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "credentialId" to it.credentialId,
               "createdAt" to it.createdAt,
               "userId" to it.userId,
-              "lastAuthenticatedAt" to it.lastAuthenticatedAt
+              "lastAuthenticatedAt" to it.lastAuthenticatedAt,
+              "expiresAt" to it.expiresAt,
             )
 
             result.success(data)
@@ -215,7 +216,8 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "credentialId" to it.credentialId,
               "createdAt" to it.createdAt,
               "userId" to it.userId,
-              "lastAuthenticatedAt" to it.lastAuthenticatedAt
+              "lastAuthenticatedAt" to it.lastAuthenticatedAt,
+              "expiresAt" to it.expiresAt,
             )
 
             result.success(data)
@@ -269,10 +271,11 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
       }
 
       "push.updateCredential" -> {
-        val pushToken = call.argument<String>("pushToken")!!
+        val pushToken = call.argument<String>("pushToken")
+        val resetExpiry = call.argument<Boolean>("resetExpiry") ?: false
 
         coroutineScope.launch {
-          val response = push.updateCredential(pushToken)
+          val response = push.updateCredential(pushToken, resetExpiry)
 
           handleResponse(response, result)?.let {
             val data = mapOf(
@@ -280,6 +283,7 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "userId" to it.userId,
               "lastVerifiedAt" to it.lastVerifiedAt,
               "pushToken" to it.pushToken,
+              "expiresAt" to it.expiresAt,
             )
 
             result.success(data)

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:authsignal_flutter/authsignal_flutter.dart';
 import '../config.dart';
 import '../services/backend_service.dart';
@@ -934,6 +935,11 @@ class _HomeScreenState extends State<HomeScreen> {
           label: const Text('Get Credential'),
         ),
         ElevatedButton.icon(
+          onPressed: _isInitialized ? _copyPushPublicKey : null,
+          icon: const Icon(Icons.copy, size: 18),
+          label: const Text('Copy Public Key'),
+        ),
+        ElevatedButton.icon(
           onPressed: _isInitialized ? _addPushCredential : null,
           icon: const Icon(Icons.add_circle, size: 18),
           label: const Text('Enroll Push'),
@@ -942,6 +948,11 @@ class _HomeScreenState extends State<HomeScreen> {
           onPressed: _isInitialized ? _updatePushCredential : null,
           icon: const Icon(Icons.sync, size: 18),
           label: const Text('Update Token'),
+        ),
+        ElevatedButton.icon(
+          onPressed: _isInitialized ? _resetPushCredentialExpiry : null,
+          icon: const Icon(Icons.update, size: 18),
+          label: const Text('Reset Expiry'),
         ),
         ElevatedButton.icon(
           onPressed: _isInitialized ? _getPushChallenge : null,
@@ -985,6 +996,29 @@ class _HomeScreenState extends State<HomeScreen> {
       _addOutput('✅ Push credential found');
       _addOutput('   Credential ID: ${credential.credentialId}');
       _addOutput('   User ID: ${credential.userId}');
+      if (credential.expiresAt != null) {
+        _addOutput('   Expires At: ${credential.expiresAt}');
+      }
+    } catch (e) {
+      _addOutput('❌ Error: $e');
+    }
+  }
+
+  Future<void> _copyPushPublicKey() async {
+    try {
+      final result = await authsignal.push.getCredential();
+      final credential = result.data;
+
+      if (credential == null) {
+        _addOutput(result.error != null
+            ? '❌ Error: ${result.error}'
+            : 'ℹ️ No push credential on this device');
+        return;
+      }
+
+      await Clipboard.setData(ClipboardData(text: credential.credentialId));
+      _addOutput('✅ Public key copied');
+      _addOutput('   ${credential.credentialId}');
     } catch (e) {
       _addOutput('❌ Error: $e');
     }
@@ -1024,6 +1058,9 @@ class _HomeScreenState extends State<HomeScreen> {
         _addOutput('✅ Push credential enrolled!');
         _addOutput('   Credential ID: ${result.data!.credentialId}');
         _addOutput('   User ID: ${result.data!.userId}');
+        if (result.data!.expiresAt != null) {
+          _addOutput('   Expires At: ${result.data!.expiresAt}');
+        }
       } else {
         _addOutput('❌ Failed to enroll push: ${result.error}');
       }
@@ -1045,14 +1082,41 @@ class _HomeScreenState extends State<HomeScreen> {
       _addOutput('   Push token (${PushService.mode.name}): '
           '${pushToken.substring(0, pushToken.length.clamp(0, 12))}…');
 
-      final result = await authsignal.push.updateCredential(pushToken);
+      final result = await authsignal.push.updateCredential(
+        UpdateCredentialInput(pushToken: pushToken),
+      );
 
       if (result.data != null) {
         _addOutput('✅ Push credential updated!');
         _addOutput('   Authenticator ID: ${result.data!.userAuthenticatorId}');
         _addOutput('   User ID: ${result.data!.userId}');
+        if (result.data!.expiresAt != null) {
+          _addOutput('   Expires At: ${result.data!.expiresAt}');
+        }
       } else {
         _addOutput('❌ Failed to update push credential: ${result.error}');
+      }
+    } catch (e) {
+      _addOutput('❌ Error: $e');
+    }
+  }
+
+  Future<void> _resetPushCredentialExpiry() async {
+    try {
+      _addOutput('📬 Resetting push credential expiry...');
+
+      final result = await authsignal.push.updateCredential(
+        const UpdateCredentialInput(resetExpiry: true),
+      );
+
+      if (result.data != null) {
+        _addOutput('✅ Push credential expiry reset!');
+        _addOutput('   Authenticator ID: ${result.data!.userAuthenticatorId}');
+        if (result.data!.expiresAt != null) {
+          _addOutput('   New Expires At: ${result.data!.expiresAt}');
+        }
+      } else {
+        _addOutput('❌ Failed to reset push expiry: ${result.error}');
       }
     } catch (e) {
       _addOutput('❌ Error: $e');

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import Authsignal
 
-private let authsignalFlutterVersion = "3.1.0"
+private let authsignalFlutterVersion = "3.2.0"
 
 public class AuthsignalPlugin: NSObject, FlutterPlugin {
   var passkey: AuthsignalPasskey?
@@ -170,6 +170,7 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "createdAt": data.createdAt,
             "userId": data.userId,
             "lastAuthenticatedAt": data.lastAuthenticatedAt,
+            "expiresAt": data.expiresAt,
           ]
 
           result(credential)
@@ -204,6 +205,7 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "createdAt": data.createdAt,
             "userId": data.userId,
             "lastAuthenticatedAt": data.lastAuthenticatedAt,
+            "expiresAt": data.expiresAt,
           ]
 
           result(credential)
@@ -272,10 +274,14 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
 
     case "push.updateCredential":
       let arguments = call.arguments as! [String: Any]
-      let pushToken = arguments["pushToken"] as! String
+      let pushToken = arguments["pushToken"] as? String
+      let resetExpiry = arguments["resetExpiry"] as? Bool ?? false
 
       Task.init {
-        let response = await self.push!.updateCredential(pushToken: pushToken)
+        let response = await self.push!.updateCredential(
+          pushToken: pushToken,
+          resetExpiry: resetExpiry
+        )
 
         if response.error != nil {
           let error = FlutterError(code: response.errorCode ?? "unexpected_error", message: response.error, details: "")
@@ -286,6 +292,7 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "userId": data.userId,
             "lastVerifiedAt": data.lastVerifiedAt,
             "pushToken": data.pushToken,
+            "expiresAt": data.expiresAt,
           ]
 
           result(credential)

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '3.1.0'
+  s.version          = '3.2.0'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Authsignal', '~> 2.11.0'
+  s.dependency 'Authsignal', '~> 2.12.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/authsignal_flutter.dart
+++ b/lib/authsignal_flutter.dart
@@ -18,6 +18,7 @@ export 'src/types.dart'
         TokenPayloadOther,
         ErrorCode,
         AppCredential,
+        UpdateCredentialInput,
         UpdatedAppCredential,
         AppChallenge,
         SignUpResponse,

--- a/lib/src/authsignal_push.dart
+++ b/lib/src/authsignal_push.dart
@@ -121,10 +121,29 @@ class AuthsignalPush {
   }
 
   Future<AuthsignalResponse<UpdatedAppCredential>> updateCredential(
-      String pushToken) async {
+      [Object? input]) async {
     await initCheck();
 
-    final arguments = <String, dynamic>{'pushToken': pushToken};
+    String? pushToken;
+    var resetExpiry = false;
+
+    if (input is String) {
+      pushToken = input;
+    } else if (input is UpdateCredentialInput) {
+      pushToken = input.pushToken;
+      resetExpiry = input.resetExpiry;
+    } else if (input != null) {
+      throw ArgumentError.value(
+        input,
+        'input',
+        'Must be a push token string or UpdateCredentialInput.',
+      );
+    }
+
+    final arguments = <String, dynamic>{
+      'pushToken': pushToken,
+      'resetExpiry': resetExpiry,
+    };
 
     try {
       final data = await methodChannel.invokeMapMethod<String, dynamic>(

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -92,12 +92,14 @@ class AppCredential {
   String createdAt;
   String userId;
   String? lastAuthenticatedAt;
+  String? expiresAt;
 
   AppCredential({
     required this.credentialId,
     required this.createdAt,
     required this.userId,
     required this.lastAuthenticatedAt,
+    this.expiresAt,
   });
 
   factory AppCredential.fromMap(Map<String, dynamic> map) {
@@ -106,21 +108,34 @@ class AppCredential {
       createdAt: map['createdAt'],
       userId: map['userId'],
       lastAuthenticatedAt: map['lastAuthenticatedAt'],
+      expiresAt: map['expiresAt'],
     );
   }
+}
+
+class UpdateCredentialInput {
+  final String? pushToken;
+  final bool resetExpiry;
+
+  const UpdateCredentialInput({
+    this.pushToken,
+    this.resetExpiry = false,
+  });
 }
 
 class UpdatedAppCredential {
   final String userAuthenticatorId;
   final String userId;
   final String lastVerifiedAt;
-  final String pushToken;
+  final String? pushToken;
+  final String? expiresAt;
 
   UpdatedAppCredential({
     required this.userAuthenticatorId,
     required this.userId,
     required this.lastVerifiedAt,
-    required this.pushToken,
+    this.pushToken,
+    this.expiresAt,
   });
 
   factory UpdatedAppCredential.fromMap(Map<String, dynamic> map) {
@@ -129,6 +144,7 @@ class UpdatedAppCredential {
       userId: map['userId'],
       lastVerifiedAt: map['lastVerifiedAt'],
       pushToken: map['pushToken'],
+      expiresAt: map['expiresAt'],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 3.1.0
+version: 3.2.0
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:

--- a/test/authsignal_test.dart
+++ b/test/authsignal_test.dart
@@ -31,7 +31,8 @@ void main() {
                 'credentialId': 'test_push_credential_id',
                 'createdAt': '2023-01-01T00:00:00Z',
                 'userId': 'test_user_id',
-                'lastAuthenticatedAt': '2023-01-02T00:00:00Z'
+                'lastAuthenticatedAt': '2023-01-02T00:00:00Z',
+                'expiresAt': '2026-01-01T00:00:00Z',
               };
             }
 
@@ -41,7 +42,8 @@ void main() {
                 'credentialId': 'new_push_credential_id',
                 'createdAt': '2023-01-01T00:00:00Z',
                 'userId': 'test_user_id',
-                'lastAuthenticatedAt': null
+                'lastAuthenticatedAt': null,
+                'expiresAt': '2026-01-01T00:00:00Z',
               };
             }
 
@@ -69,11 +71,16 @@ void main() {
 
           case "push.updateCredential":
             {
+              final arguments =
+                  (methodCall.arguments as Map).cast<String, dynamic>();
               return <String, dynamic>{
                 'userAuthenticatorId': 'test_push_authenticator_id',
                 'userId': 'test_user_id',
                 'lastVerifiedAt': '2023-01-03T00:00:00Z',
-                'pushToken': methodCall.arguments['pushToken'],
+                'pushToken': arguments['pushToken'],
+                'expiresAt': arguments['resetExpiry'] == true
+                    ? '2026-02-01T00:00:00Z'
+                    : '2026-01-01T00:00:00Z',
               };
             }
 
@@ -223,6 +230,7 @@ void main() {
     expect(result.data!.userId, 'test_user_id');
     expect(result.data!.createdAt, '2023-01-01T00:00:00Z');
     expect(result.data!.lastAuthenticatedAt, '2023-01-02T00:00:00Z');
+    expect(result.data!.expiresAt, '2026-01-01T00:00:00Z');
   });
 
   test('push.addCredential', () async {
@@ -232,6 +240,7 @@ void main() {
     expect(result.data!.userId, 'test_user_id');
     expect(result.data!.createdAt, '2023-01-01T00:00:00Z');
     expect(result.data!.lastAuthenticatedAt, null);
+    expect(result.data!.expiresAt, '2026-01-01T00:00:00Z');
   });
 
   test('push.removeCredential', () async {
@@ -267,6 +276,19 @@ void main() {
     expect(result.data!.userId, 'test_user_id');
     expect(result.data!.lastVerifiedAt, '2023-01-03T00:00:00Z');
     expect(result.data!.pushToken, 'test-push-token');
+    expect(result.data!.expiresAt, '2026-01-01T00:00:00Z');
+  });
+
+  test('push.updateCredential reset expiry', () async {
+    final result = await authsignal.push.updateCredential(
+      const UpdateCredentialInput(resetExpiry: true),
+    );
+
+    expect(result.data!.userAuthenticatorId, 'test_push_authenticator_id');
+    expect(result.data!.userId, 'test_user_id');
+    expect(result.data!.lastVerifiedAt, '2023-01-03T00:00:00Z');
+    expect(result.data!.pushToken, null);
+    expect(result.data!.expiresAt, '2026-02-01T00:00:00Z');
   });
 
   test('qr.getCredential', () async {


### PR DESCRIPTION
### Breaking Changes
None.

### New Features
- Added push credential expiry support.
- Added `resetExpiry` support for `push.updateCredential`.
- Added `expiresAt` to push credential responses.
- Updated native SDK deps to iOS `~> 2.12.0` and Android `4.2.0`.

### Bug Fixes
None.

### Checklist
- [x] Version bumped
- [ ] Documentation updated
