### PR TITLE
Add credential delivery error fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.0
+
+- Added optional `erroredAt` and `errorCode` fields to push credential responses, set when APNs or FCM report that the credential's push token is no longer valid.
+- Updated native dependencies to Authsignal iOS `~> 2.14.0` and Authsignal Android `4.4.0`.
+
 ## 3.3.0
 
 - Added `expiresAt` to push challenge responses returned by `push.getChallenge()`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^3.3.0
+  authsignal_flutter: ^3.4.0
 ```
 
 Then install the package:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.authsignal:authsignal-android:4.3.0'
+        implementation 'com.authsignal:authsignal-android:4.4.0'
         implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1'
     }
 }

--- a/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
+++ b/android/src/main/kotlin/com/authsignal/authsignal_flutter/AuthsignalPlugin.kt
@@ -192,6 +192,8 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "userId" to it.userId,
               "lastAuthenticatedAt" to it.lastAuthenticatedAt,
               "expiresAt" to it.expiresAt,
+              "erroredAt" to it.erroredAt,
+              "errorCode" to it.errorCode,
             )
 
             result.success(data)
@@ -218,6 +220,8 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "userId" to it.userId,
               "lastAuthenticatedAt" to it.lastAuthenticatedAt,
               "expiresAt" to it.expiresAt,
+              "erroredAt" to it.erroredAt,
+              "errorCode" to it.errorCode,
             )
 
             result.success(data)
@@ -285,6 +289,8 @@ class AuthsignalPlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
               "lastVerifiedAt" to it.lastVerifiedAt,
               "pushToken" to it.pushToken,
               "expiresAt" to it.expiresAt,
+              "erroredAt" to it.erroredAt,
+              "errorCode" to it.errorCode,
             )
 
             result.success(data)

--- a/ios/Classes/AuthsignalPlugin.swift
+++ b/ios/Classes/AuthsignalPlugin.swift
@@ -171,6 +171,8 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "userId": data.userId,
             "lastAuthenticatedAt": data.lastAuthenticatedAt,
             "expiresAt": data.expiresAt,
+            "erroredAt": data.erroredAt,
+            "errorCode": data.errorCode,
           ]
 
           result(credential)
@@ -206,6 +208,8 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "userId": data.userId,
             "lastAuthenticatedAt": data.lastAuthenticatedAt,
             "expiresAt": data.expiresAt,
+            "erroredAt": data.erroredAt,
+            "errorCode": data.errorCode,
           ]
 
           result(credential)
@@ -294,6 +298,8 @@ public class AuthsignalPlugin: NSObject, FlutterPlugin {
             "lastVerifiedAt": data.lastVerifiedAt,
             "pushToken": data.pushToken,
             "expiresAt": data.expiresAt,
+            "erroredAt": data.erroredAt,
+            "errorCode": data.errorCode,
           ]
 
           result(credential)

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '3.3.0'
+  s.version          = '3.4.0'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Authsignal', '~> 2.13.0'
+  s.dependency 'Authsignal', '~> 2.14.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -93,6 +93,8 @@ class AppCredential {
   String userId;
   String? lastAuthenticatedAt;
   String? expiresAt;
+  String? erroredAt;
+  String? errorCode;
 
   AppCredential({
     required this.credentialId,
@@ -100,6 +102,8 @@ class AppCredential {
     required this.userId,
     required this.lastAuthenticatedAt,
     this.expiresAt,
+    this.erroredAt,
+    this.errorCode,
   });
 
   factory AppCredential.fromMap(Map<String, dynamic> map) {
@@ -109,6 +113,8 @@ class AppCredential {
       userId: map['userId'],
       lastAuthenticatedAt: map['lastAuthenticatedAt'],
       expiresAt: map['expiresAt'],
+      erroredAt: map['erroredAt'],
+      errorCode: map['errorCode'],
     );
   }
 }
@@ -129,6 +135,8 @@ class UpdatedAppCredential {
   final String lastVerifiedAt;
   final String? pushToken;
   final String? expiresAt;
+  final String? erroredAt;
+  final String? errorCode;
 
   UpdatedAppCredential({
     required this.userAuthenticatorId,
@@ -136,6 +144,8 @@ class UpdatedAppCredential {
     required this.lastVerifiedAt,
     this.pushToken,
     this.expiresAt,
+    this.erroredAt,
+    this.errorCode,
   });
 
   factory UpdatedAppCredential.fromMap(Map<String, dynamic> map) {
@@ -145,6 +155,8 @@ class UpdatedAppCredential {
       lastVerifiedAt: map['lastVerifiedAt'],
       pushToken: map['pushToken'],
       expiresAt: map['expiresAt'],
+      erroredAt: map['erroredAt'],
+      errorCode: map['errorCode'],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 3.3.0
+version: 3.4.0
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:


### PR DESCRIPTION
When APNs or FCM report that a device's push token is no longer valid, the credential's authenticator now records `erroredAt` and `errorCode` server-side. This exposes those fields on `AppCredential` and `UpdatedAppCredential`, so an app can check `push.getCredential()` on launch and re-register its push token via `push.updateCredential` when the credential has a delivery error.

## Changes

- Adds optional `erroredAt` and `errorCode` to `AppCredential` and `UpdatedAppCredential`, including `fromMap` parsing.
- Bridges the fields through both platform plugins.
- `errorCode` is the push provider's own code passed through as-is (e.g. `Unregistered` from APNs, `UNREGISTERED` from FCM).
- Bumps native dependencies to Authsignal iOS 2.14.0 and Android 4.4.0, and version to 3.4.0.

Depends on authsignal/authsignal-ios#86 and authsignal/authsignal-android#98 being released. The fields are optional and `null` until the corresponding API change is live.