### PR TITLE
Add Swift Package Manager support for iOS

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,32 +1,32 @@
-name-template: "v$RESOLVED_VERSION 🚀"
+name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
-  - title: "⚠️ Breaking Changes"
+  - title: "Breaking changes"
     labels:
       - "breaking"
       - "major"
-  - title: "🚀 Features"
+  - title: "New features"
     labels:
       - "feature"
       - "enhancement"
-  - title: "🐛 Bug Fixes"
+  - title: "Bug fixes"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
-  - title: "🧰 Maintenance"
+  - title: "Maintenance"
     labels:
       - "chore"
       - "maintenance"
-  - title: "📚 Documentation"
+  - title: "Documentation"
     labels:
       - "documentation"
-  - title: "⬆️ Dependencies"
+  - title: "Dependencies"
     collapse-after: 5
     labels:
       - "dependencies"
 
-change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: '\<*_&'
 version-resolver:
   major:
@@ -37,6 +37,7 @@ version-resolver:
     labels:
       - "minor"
       - "feature"
+      - "enhancement"
   patch:
     labels:
       - "patch"
@@ -68,9 +69,6 @@ autolabeler:
       - "pubspec.lock"
 
 template: |
-  ## Changes in Release v$RESOLVED_VERSION
-
   $CHANGES
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ migrate_working_dir/
 /pubspec.lock
 **/doc/api/
 .dart_tool/
+.build/
+.swiftpm/
 build/
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.1
+
+- Added Swift Package Manager support for iOS while retaining CocoaPods compatibility.
+
 ## 3.3.0
 
 - Added `expiresAt` to push challenge responses returned by `push.getChallenge()`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the Authsignal Flutter SDK to your project:
 
 ```yaml
 dependencies:
-  authsignal_flutter: ^3.3.0
+  authsignal_flutter: ^3.3.1
 ```
 
 Then install the package:
@@ -19,7 +19,9 @@ Then install the package:
 flutter pub get
 ```
 
-For iOS apps, install CocoaPods dependencies:
+Flutter 3.44 and newer resolve iOS dependencies with Swift Package Manager by default.
+The SDK also continues to support CocoaPods. For projects using CocoaPods, install the
+iOS dependencies with:
 
 ```bash
 cd ios && pod install

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.authsignal.authsignal_flutter'
-version '3.3.0'
+version '3.3.1'
 
 buildscript {
     ext.kotlin_version = '2.1.21'

--- a/ios/authsignal_flutter.podspec
+++ b/ios/authsignal_flutter.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = 'authsignal_flutter'
-  s.version          = '3.3.0'
+  s.version          = '3.3.1'
   s.summary          = 'The Authsignal Flutter SDK.'
   s.description      = 'The Authsignal Flutter SDK.'
   s.homepage         = 'https://www.authsignal.com'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Authsignal' => 'support@authsignal.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'authsignal_flutter/Sources/authsignal_flutter/**/*.swift'
   s.dependency 'Flutter'
   s.dependency 'Authsignal', '~> 2.13.0'
   s.platform = :ios, '13.0'

--- a/ios/authsignal_flutter/Package.swift
+++ b/ios/authsignal_flutter/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+  name: "authsignal_flutter",
+  platforms: [
+    .iOS("13.0")
+  ],
+  products: [
+    .library(
+      name: "authsignal-flutter",
+      targets: ["authsignal_flutter"]
+    )
+  ],
+  dependencies: [
+    .package(name: "FlutterFramework", path: "../FlutterFramework"),
+    .package(
+      url: "https://github.com/authsignal/authsignal-ios.git",
+      .upToNextMinor(from: "2.13.0")
+    )
+  ],
+  targets: [
+    .target(
+      name: "authsignal_flutter",
+      dependencies: [
+        .product(name: "FlutterFramework", package: "FlutterFramework"),
+        .product(name: "Authsignal", package: "authsignal-ios")
+      ]
+    )
+  ]
+)

--- a/ios/authsignal_flutter/Sources/authsignal_flutter/AuthsignalPlugin.swift
+++ b/ios/authsignal_flutter/Sources/authsignal_flutter/AuthsignalPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import UIKit
 import Authsignal
 
-private let authsignalFlutterVersion = "3.3.0"
+private let authsignalFlutterVersion = "3.3.1"
 
 public class AuthsignalPlugin: NSObject, FlutterPlugin {
   var passkey: AuthsignalPasskey?

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: authsignal_flutter
 description: "The Authsignal Flutter SDK for Passkeys, Push, QR, and In-App Authentication"
-version: 3.3.0
+version: 3.3.1
 homepage: "https://github.com/authsignal/authsignal-flutter"
 
 environment:


### PR DESCRIPTION
### Breaking Changes

None.

### New Features

- Added Swift Package Manager support for iOS while retaining CocoaPods compatibility.

### Bug Fixes

- Removed the Flutter 3.44 warning that authsignal_flutter requires CocoaPods.


### Checklist

- [x] Version bumped
- [ ] Documentation updated